### PR TITLE
Fix the tax mismatch issue #1

### DIFF
--- a/SOOrderEntryExt.cs
+++ b/SOOrderEntryExt.cs
@@ -351,7 +351,17 @@ namespace PXDropShipPOExtPkg
                 }
 
                 //Save the order
-                orderEntryGraph.Actions.PressSave();
+                ty
+				{
+					orderEntryGraph.RecalculateExternalTaxesSync = true;
+					orderEntryGraph.Actions.PressSave();
+				}
+				finally
+				{
+					orderEntryGraph.RecalculateExternalTaxesSync = false;
+				}
+                
+                order = orderEntryGraph.Document.Current;
             }
         }
 


### PR DESCRIPTION
1. Save order properly with taxes recalculation
2. Update the order back
However, one scenario does not seem to be working with the fix.
The scenario is like that: Warehouse was changed and tax was recalculated. However, due to that change, order total became less than payment total applied to the order. So, what should happen?