### PR TITLE
Fix Tax mismatch issue #2

### DIFF
--- a/SOOrderEntryExt.cs
+++ b/SOOrderEntryExt.cs
@@ -349,7 +349,14 @@ namespace PXDropShipPOExtPkg
                         }
                     }
                 }
-
+                
+                //We do not want to recalculate taxes here. We'll have recalculation and write off when Invoice is created
+                //So we restore all the tax flags to their initial values
+                orderEntryGraph.Document.Current.IsTaxValid = order.IsTaxValid;
+                orderEntryGraph.Document.Current.IsOpenTaxValid = order.IsOpenTaxValid;
+                orderEntryGraph.Document.Current.IsUnbilledTaxValid = order.IsUnbilledTaxValid;
+                orderEntryGraph.Document.Current.IsFreightTaxValid = order.IsFreightTaxValid;
+                
                 //Save the order
                 orderEntryGraph.Actions.PressSave();
             }


### PR DESCRIPTION
If tax recalculated on changing warehouse, we can get into the situation when Payment amount applied to Order is greater than Order Total. We'd like to avoid that situation.